### PR TITLE
Static query language

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ description   := "Scala graph API"
 organization  := "ohnosequences"
 bucketSuffix  := "era7.com"
 
-scalaVersion        := "2.11.4"
+scalaVersion        := "2.11.5"
 crossScalaVersions  := Seq("2.10.4")
 
 libraryDependencies ++= Seq(
@@ -16,8 +16,8 @@ libraryDependencies ++= Seq(
   },
   "ohnosequences"           %% "cosas"       % "0.6.0-SNAPSHOT",
   "org.scalaz"              %% "scalaz-core" % "7.1.0",
-  "com.thinkaurelius.titan" %  "titan-core"  % "0.5.2",
-  "org.scalatest"           %% "scalatest"   % "2.2.2" % Test,
+  "com.thinkaurelius.titan" %  "titan-core"  % "0.5.3",
+  "org.scalatest"           %% "scalatest"   % "2.2.3" % Test,
   "org.slf4j"               %  "slf4j-nop"   % "1.7.5" % Test
   // ^ getting rid of the annoying warning about logging ^
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,5 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 
-resolvers += "Era7 maven snapshots" at "https://s3-eu-west-1.amazonaws.com/snapshots.era7.com"
+// resolvers += "Era7 maven snapshots" at "https://s3-eu-west-1.amazonaws.com/snapshots.era7.com"
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.5.0-RC1")
-
-// These versions fix the bug with unicode symbols:
-// addSbtPlugin("laughedelic" % "literator-plugin" % "0.5.2")
-
-// addSbtPlugin("com.markatta" % "taglist-plugin" % "1.3.1")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.5.1")

--- a/src/main/scala/ohnosequences/scarph/GraphTypes.scala
+++ b/src/main/scala/ohnosequences/scarph/GraphTypes.scala
@@ -28,31 +28,6 @@ object graphTypes {
     (x: EqualityContext[A,B]) => new Refl[B] {} 
   }
 
-  // implicit def coerce[A <: AnyGraphType, B <: AnyGraphType](a: A)(implicit eqWitness: Equality[A,B]): Equality[A,B]#Out = a
-
-  // this is `\simeq` symbol
-  object EqualityContext {
-
-    // trait Refl[A <: AnyGraphType] extends (A Equality A) { type Out = A }
-    // implicit def refl[A >: B <: B, B <: AnyGraphType, X <: EqualityContext[A,B]]: A Equality B = new Refl[B] {}
-  }
-  
-  trait simeq2 extends simeq3 {
-    // implicit def eq[A <: AnyGraphType, B <: AnyGraphType]
-    //   (implicit 
-    //     cont: A#Container =:= B#Container,
-    //     insd: A#Inside ≃ B#Inside
-    //   ): A ≃ B = new (A ≃ B) {} 
-  }
-
-  trait simeq3 {
-
-    // implicit def eqSimple[A <: AnySimpleGraphType, B <: AnySimpleGraphType]
-    //   (implicit
-    //     insd: A#Inside ≃ B#Inside
-    //   ): A ≃ B = new (A ≃ B) {}  
-
-  }
 
   /* This is a non-nested graph type */
   trait AnySimpleGraphType extends AnyGraphType {

--- a/src/main/scala/ohnosequences/scarph/Schemas.scala
+++ b/src/main/scala/ohnosequences/scarph/Schemas.scala
@@ -5,7 +5,7 @@ object schemas {
   import ohnosequences.cosas._, typeSets._
   import graphTypes._, indexes._
 
-  trait AnySchema extends AnySimpleGraphType {
+  trait AnyGraphSchema extends AnySimpleGraphType {
 
     type Properties <: AnyTypeSet.Of[AnyGraphProperty]
     val  properties: Properties
@@ -20,7 +20,7 @@ object schemas {
     val  indexes: Indexes
   }
 
-  abstract class Schema[
+  abstract class GraphSchema[
       Ps <: AnyTypeSet.Of[AnyGraphProperty],
       Vs <: AnyTypeSet.Of[AnyVertex],
       Es <: AnyTypeSet.Of[AnyEdge],
@@ -30,24 +30,24 @@ object schemas {
       val vertices: Vs,
       val edges: Es,
       val indexes: Is
-    ) extends AnySchema {
+    ) extends AnyGraphSchema {
 
     type Properties = Ps
     type Vertices = Vs
     type Edges = Es
     type Indexes = Is
 
-    type Inside = Schema[Ps,Vs,Es,Is]
+    type Inside = GraphSchema[Ps,Vs,Es,Is]
   }
 
-  object AnySchemaType {
+  object AnyGraphSchemaType {
 
-    implicit def schemaOps[GS <: AnySchema](gs: GS):
-          SchemaOps[GS] =
-      new SchemaOps[GS](gs)
+    implicit def schemaOps[GS <: AnyGraphSchema](gs: GS):
+          GraphSchemaOps[GS] =
+      new GraphSchemaOps[GS](gs)
   }
 
-  class SchemaOps[GS <: AnySchema](gs: GS) {
+  class GraphSchemaOps[GS <: AnyGraphSchema](gs: GS) {
 
     // TODO: filter schema properties by an owner
     // def propertiesOf[E <: AnyGraphElement](e: E)

--- a/src/main/scala/ohnosequences/scarph/Steps.scala
+++ b/src/main/scala/ohnosequences/scarph/Steps.scala
@@ -101,7 +101,7 @@ object steps {
     type Inside = Target[E]
   }
 
-  case class GraphQuery[S <: AnySchema, C <: AnyContainer, P <: AnyPredicate]
+  case class GraphQuery[S <: AnyGraphSchema, C <: AnyContainer, P <: AnyPredicate]
     (val graph: S, val c: C, val predicate: P)
       extends Step[S, C#Of[P#Element]](graph, c.of(predicate.element)) {
 

--- a/src/main/scala/ohnosequences/scarph/impl/titan/Evals.scala
+++ b/src/main/scala/ohnosequences/scarph/impl/titan/Evals.scala
@@ -119,7 +119,7 @@ case object evals {
 
 
   implicit def evalVertexQuery[
-    S <: AnySchema, P <: AnyPredicate { type Element <: AnyVertex }, C <: AnyContainer, O
+    S <: AnyGraphSchema, P <: AnyPredicate { type Element <: AnyVertex }, C <: AnyContainer, O
   ](implicit 
     toBlueprintsQuery: ToBlueprintsPredicate[P],
     packValue: ValueContainer[C, JIterable[TitanVertex]] { type Out = O }
@@ -134,7 +134,7 @@ case object evals {
   }
 
   implicit def evalEdgeQuery[
-    S <: AnySchema, P <: AnyPredicate { type Element <: AnyEdge }, C <: AnyContainer, O
+    S <: AnyGraphSchema, P <: AnyPredicate { type Element <: AnyEdge }, C <: AnyContainer, O
   ](implicit 
     toBlueprintsQuery: ToBlueprintsPredicate[P],
     packValue: ValueContainer[C, JIterable[TitanEdge]] { type Out = O }

--- a/src/main/scala/ohnosequences/scarph/syntax/Paths.scala
+++ b/src/main/scala/ohnosequences/scarph/syntax/Paths.scala
@@ -9,11 +9,11 @@ object paths {
 
 
   /* Graph/schema ops */
-  implicit def schemaOps[S <: AnySchema](s: S):
+  implicit def schemaOps[S <: AnyGraphSchema](s: S):
         SchemaOps[S] =
     new SchemaOps[S](s)
 
-  class SchemaOps[S <: AnySchema](s: S) {
+  class SchemaOps[S <: AnyGraphSchema](s: S) {
 
     def query[P <: AnyPredicate](p: P): 
       GraphQuery[S, ManyOrNone, P] = 

--- a/src/test/scala/ohnosequences/scarph/TwitterSchema.scala
+++ b/src/test/scala/ohnosequences/scarph/TwitterSchema.scala
@@ -32,7 +32,7 @@ object Twitter {
   // vertex-centric indexes
   case object postedByTimeAndUrlLocal extends LocalEdgeIndex(posted, OnlySourceCentric, time :~: url :~: ∅)
 
-  case object twitter extends Schema(
+  case object twitter extends GraphSchema(
     label = "twitter",
     properties = name :~: age :~: text :~: time :~: url :~: ∅,
     vertices =  user :~: tweet :~: ∅,

--- a/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
+++ b/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
@@ -43,29 +43,7 @@ trait AnyTitanTestSuite
 
 class TitanTestSuite extends AnyTitanTestSuite {
 
-  // checks existence and arity
-  def checkEdgeLabel[ET <: AnyEdge](mgmt: TitanManagement, et: ET)
-    (implicit multi: EdgeTypeMultiplicity[ET]) = {
-
-    assert{ mgmt.containsRelationType(et.label) }
-
-    assertResult(multi(et)) {
-      mgmt.getEdgeLabel(et.label).getMultiplicity
-    }
-  }
-
-  import ohnosequences.cosas._, fns._
-  import ohnosequences.cosas.ops.typeSets.MapToList
-
-  // TODO: make it a graph op: checkSchema
   test("check schema keys/labels") {
-
-    val mgmt = g.getManagementSystem
-
-    checkEdgeLabel(mgmt, posted)
-    checkEdgeLabel(mgmt, follows)
-
-    mgmt.commit
 
     val errors = titanTwitter.checkSchema
     if (errors.nonEmpty) errors.foreach{ err => info(err.msg) }

--- a/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
+++ b/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
@@ -82,9 +82,6 @@ class TitanTestSuite extends AnyTitanTestSuite {
     checkEdgeLabel(mgmt, posted)
     checkEdgeLabel(mgmt, follows)
 
-    assert{ mgmt.containsVertexLabel(user.label) }
-    assert{ mgmt.containsVertexLabel(tweet.label) }
-
     checkCompositeIndex(mgmt, userByName)
     checkCompositeIndex(mgmt, tweetByText)
     checkCompositeIndex(mgmt, postedByTime)
@@ -92,7 +89,9 @@ class TitanTestSuite extends AnyTitanTestSuite {
 
     mgmt.commit
 
-    assert{ titanTwitter.checkSchema.forall(_.isRight) }
+    val errors = titanTwitter.checkSchema
+    if (errors.nonEmpty) errors.foreach{ err => info(err.msg) }
+    assert{ errors.isEmpty }
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
+++ b/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
@@ -56,23 +56,6 @@ class TitanTestSuite extends AnyTitanTestSuite {
 
   import ohnosequences.cosas._, fns._
   import ohnosequences.cosas.ops.typeSets.MapToList
-  // checks existence, type and the indexed property
-  def checkCompositeIndex[Ix <: AnyCompositeIndex](mgmt: TitanManagement, ix: Ix)
-    (implicit propLabels: MapToList[propertyLabel.type, Ix#Properties] with InContainer[String]) = {
-
-    assert{ mgmt.containsGraphIndex(ix.label) }
-
-    val index = mgmt.getGraphIndex(ix.label)
-    // TODO: check for mixed indexes and any other stuff
-    assert{ index.isCompositeIndex }
-    assert{ index.isUnique == ix.uniqueness.bool }
-
-    val ixPropertyKeys: Set[PropertyKey] = 
-      propLabels(ix.properties).map{ mgmt.getPropertyKey(_) }.toSet
-
-    assert{ index.getFieldKeys.toSet == ixPropertyKeys }
-    // println(ixPropertyKeys.mkString(s"[${ix.label}] property keys: {", ", ", "}"))
-  }
 
   // TODO: make it a graph op: checkSchema
   test("check schema keys/labels") {
@@ -81,11 +64,6 @@ class TitanTestSuite extends AnyTitanTestSuite {
 
     checkEdgeLabel(mgmt, posted)
     checkEdgeLabel(mgmt, follows)
-
-    checkCompositeIndex(mgmt, userByName)
-    checkCompositeIndex(mgmt, tweetByText)
-    checkCompositeIndex(mgmt, postedByTime)
-    checkCompositeIndex(mgmt, userByNameAndAge)
 
     mgmt.commit
 

--- a/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
+++ b/src/test/scala/ohnosequences/scarph/titan/TwitterTitanTest.scala
@@ -23,7 +23,7 @@ trait AnyTitanTestSuite
   val titanTwitter = twitter := g
 
   override def beforeAll() {
-    titanTwitter.createSchema(twitter)
+    titanTwitter.createSchema
 
     // loading data from a prepared GraphSON file
     import com.tinkerpop.blueprints.util.io.graphson._
@@ -54,23 +54,6 @@ class TitanTestSuite extends AnyTitanTestSuite {
     }
   }
 
-  // checks existence and dataType
-  def checkPropertyKey[P <: AnyGraphProperty](mgmt: TitanManagement, p: P)
-    (implicit cc: scala.reflect.ClassTag[P#Raw]) = {
-
-    assert{ mgmt.containsRelationType(p.label) }
-
-    val pkey: PropertyKey = mgmt.getPropertyKey(p.label)
-
-    assertResult( com.thinkaurelius.titan.core.Cardinality.SINGLE ) { 
-      pkey.getCardinality 
-    }
-
-    assertResult( cc.runtimeClass.asInstanceOf[Class[P#Raw]] ) {
-      pkey.getDataType
-    }
-  }
-
   import ohnosequences.cosas._, fns._
   import ohnosequences.cosas.ops.typeSets.MapToList
   // checks existence, type and the indexed property
@@ -96,12 +79,6 @@ class TitanTestSuite extends AnyTitanTestSuite {
 
     val mgmt = g.getManagementSystem
 
-    checkPropertyKey(mgmt, name)
-    checkPropertyKey(mgmt, age)
-    checkPropertyKey(mgmt, text)
-    checkPropertyKey(mgmt, url)
-    checkPropertyKey(mgmt, time)
-
     checkEdgeLabel(mgmt, posted)
     checkEdgeLabel(mgmt, follows)
 
@@ -114,6 +91,8 @@ class TitanTestSuite extends AnyTitanTestSuite {
     checkCompositeIndex(mgmt, userByNameAndAge)
 
     mgmt.commit
+
+    assert{ titanTwitter.checkSchema.forall(_.isRight) }
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
By static I mean that they are defined only on "types", i.e. are implementation independent.

- [x] https://github.com/ohnosequences/cosas/pull/24: move generic stuff to cosas:
- [x] #23: arities 
- [x] #24: indexes & predicates 
- [x] #25: declaring schemas 
- [x] #26: arities as containers
- [x] #27: vertex-centric things
- [x] #28: minimal set of necessary steps
- [x] #35: predicates support
- [x] #37: Par/Or (`⨂/⨁`)
- [x] Titan implementation
  + [x] all basic steps
  + [x] schema creation
  + [ ] use titan predicates instead of blueprints (should help to avoid casting in queries)
- [x] add an example dsl syntax (gremlin-style)
- [x] automatic schema check (like creation, but check)

-----
in the end:
- [ ] refactoring, better structure
- [ ] more documentation
- [ ] fix all the warts or explicitly ignore if not possible