### PR TITLE
Trying to simplify in/out path members

### DIFF
--- a/src/main/scala/ohnosequences/scarph/Evals.scala
+++ b/src/main/scala/ohnosequences/scarph/Evals.scala
@@ -11,8 +11,8 @@ trait AnyEvalPath {
   type InVal
   type OutVal
 
-  type In = InVal Denotes InOf[Path]
-  type Out = OutVal Denotes OutOf[Path]
+  type In = InVal Denotes Path#In
+  type Out = OutVal Denotes Path#Out
 
   def apply(path: Path)(in: In): Out
 }
@@ -29,7 +29,7 @@ object AnyEvalPath {
   implicit def evalComposition[
     I, 
     F <: AnyPath,
-    G <: AnyPath { type InC = F#OutC; type InT = F#OutT },
+    G <: AnyPath { type In = F#Out },
     X, O
   ](implicit
     evalFirst:  EvalPathOn[I, F, X],
@@ -81,28 +81,28 @@ object AnyEvalPath {
     }
   }
 
-  // NOTE: this is the same a general thing, but then there is no secod container (i.e. it's virtual Id[])
-  // it is an experiment, let's see how it works (we need more tests for flatten)
-  implicit def evalFlattenWithOuterId[
-    P <: AnyPath { type OutC = ExactlyOne.type; type OutT <: AnyContainerType }, 
-    I, O
-  ](implicit
-    evalInner: EvalPathOn[I, P, O]
-  ):  EvalPathOn[I, Flatten[P, P#OutT#Container], O] = 
-  new EvalPathOn[I, Flatten[P, P#OutT#Container], O] {
-    def apply(path: Path)(in: In): Out = outOf(path) := evalInner(path.path)(in).value
-  }
+  // // NOTE: this is the same a general thing, but then there is no secod container (i.e. it's virtual Id[])
+  // // it is an experiment, let's see how it works (we need more tests for flatten)
+  // implicit def evalFlattenWithOuterId[
+  //   P <: AnyPath { type Out <: ExactlyOneOf[_ <: AnyContainerType] }, 
+  //   I, O
+  // ](implicit
+  //   evalInner: EvalPathOn[I, P, O]
+  // ):  EvalPathOn[I, Flatten[P, P#OutT#Container], O] = 
+  // new EvalPathOn[I, Flatten[P, P#OutT#Container], O] {
+  //   def apply(path: Path)(in: In): Out = outOf(path) := evalInner(path.path)(in).value
+  // }
 
-  implicit def evalFlattenWithInnerId[
-    P <: AnyPath { type OutT <: ExactlyOneOf[_] }, 
-    C <: AnyContainer,
-    I, O
-  ](implicit
-    evalInner: EvalPathOn[I, P, O]
-  ):  EvalPathOn[I, Flatten[P, C], O] = 
-  new EvalPathOn[I, Flatten[P, C], O] {
-    def apply(path: Path)(in: In): Out = outOf(path) := evalInner(path.path)(in).value
-  }
+  // implicit def evalFlattenWithInnerId[
+  //   P <: AnyPath { type OutT <: ExactlyOneOf[_] }, 
+  //   C <: AnyContainer,
+  //   I, O
+  // ](implicit
+  //   evalInner: EvalPathOn[I, P, O]
+  // ):  EvalPathOn[I, Flatten[P, C], O] = 
+  // new EvalPathOn[I, Flatten[P, C], O] {
+  //   def apply(path: Path)(in: In): Out = outOf(path) := evalInner(path.path)(in).value
+  // }
 
 
   implicit def evalPar[

--- a/src/main/scala/ohnosequences/scarph/Paths.scala
+++ b/src/main/scala/ohnosequences/scarph/Paths.scala
@@ -17,16 +17,22 @@ import AnyEvalPath._
 trait AnyPath {
 
   /* Input */
-  type InC <: AnyContainer
-  val  inC: InC
-  type InT <: AnyGraphType
-  val  inT: InT
+  type In <: AnyContainerType
+  val  in: In
+
+  type InC = In#Container
+  val  inC = in.container
+  type InT = In#Of
+  val  inT = in.of
 
   /* Output */
-  type OutC <: AnyContainer
-  val  outC: OutC
-  type OutT <: AnyGraphType
-  val  outT: OutT
+  type Out <: AnyContainerType
+  val  out: Out
+
+  type OutC = Out#Container
+  val  outC = out.container
+  type OutT = Out#Of
+  val  outT = out.of
 
   // NOTE: we will need to forget about these bounds at some point
   // type Rev <: AnyPath { type In <: path.Out; type Out <: path.In }
@@ -35,33 +41,36 @@ trait AnyPath {
 /* Important aliases which combine input/output arity container with its label type */
 object paths {
 
-  type InOf[P <: AnyPath] = P#InC#Of[P#InT]
-  type OutOf[P <: AnyPath] = P#OutC#Of[P#OutT]
+  // type InOf[P <: AnyPath] = P#In //C#Of[P#InT]
+  // type OutOf[P <: AnyPath] = P#Out //C#Of[P#OutT]
 
-  def inOf[P <: AnyPath](p: P): InOf[P] = p.inC(p.inT)
-  def outOf[P <: AnyPath](p: P): OutOf[P] = p.outC(p.outT)
+  def inOf[P <: AnyPath](p: P): P#In = p.in //C(p.inT)
+  def outOf[P <: AnyPath](p: P): P#Out = p.out //C(p.outT)
 }
 
 /* A _step_ is a simple atomic _path_ which can be evaluated directly.
    Note that it always has form "ExactlyOne to something". */
 trait AnyStep extends AnyPath {
 
-  type InC = ExactlyOne.type
-  val  inC = ExactlyOne
+  type In <: ExactlyOneOf[_]
+  // type InC <: ExactlyOne.type
+  // val  inC <: ExactlyOne
 }
 
 abstract class Step[
   IT <: AnyGraphType,
   OC <: AnyContainer,
   OT <: AnyGraphType
-](val inT: IT,
-  val outC: OC,
-  val outT: OT
+](iT: IT,
+  oC: OC,
+  oT: OT
 ) extends AnyStep {
 
-  type InT = IT
-  type OutC = OC
-  type OutT = OT
+  type In = ExactlyOne.Of[IT]
+  val  in = ExactlyOne(iT)
+
+  type Out = OC#Of[OT]
+  val  out = oC(oT): Out
 }
 
 /* See available combinators in [Combinators.scala] */
@@ -77,12 +86,12 @@ object AnyPath {
 case class PathOps[P <: AnyPath](val p: P) {
   import paths._
 
-  val in: InOf[P] = inOf(p)
-  val out: OutOf[P] = outOf(p)
+  // val in: InOf[P] = inOf(p)
+  // val out: OutOf[P] = outOf(p)
 
   // it's left here and not moved to syntax, because using syntax you shouldn't need it
-  def >=>[S <: AnyPath { type InC = P#OutC; type InT = P#OutT }](s: S): Composition[P, S] = Composition(p, s)
+  def >=>[S <: AnyPath { type In = P#Out }](s: S): Composition[P, S] = Composition(p, s)
 
-  def evalOn[I, O](input: I Denotes InOf[P])
-    (implicit eval: EvalPathOn[I, P, O]): O Denotes OutOf[P] = eval(p)(input)
+  def evalOn[I, O](input: I Denotes P#In)
+    (implicit eval: EvalPathOn[I, P, O]): O Denotes P#Out = eval(p)(input)
 }

--- a/src/main/scala/ohnosequences/scarph/syntax/Paths.scala
+++ b/src/main/scala/ohnosequences/scarph/syntax/Paths.scala
@@ -20,11 +20,11 @@ object paths {
     def get[B <: AnyGraphProperty { type Owner = E }](b: B): Get[B] = Get(b)
   }
 
-  implicit def pathElementOps[F <: AnyPath { type OutC = ExactlyOne.type; type OutT <: AnyElementType }](f: F):
+  implicit def pathElementOps[F <: AnyPath { type Out = ExactlyOneOf[_ <: AnyElementType] }](f: F):
         PathElementOps[F] =
     new PathElementOps[F](f)
 
-  class PathElementOps[F <: AnyPath { type OutC = ExactlyOne.type; type OutT <: AnyElementType }](f: F) {
+  class PathElementOps[F <: AnyPath { type Out = ExactlyOneOf[_ <: AnyElementType] }](f: F) {
 
     def get[S <: AnyGraphProperty { type Owner = F#OutT }](s: S):
       F >=> Get[S] =
@@ -83,7 +83,7 @@ object paths {
         F >=> InE[S] =
         f >=> InE(s)
 
-    def outE[S <: AnyPredicate { type ElementType <: AnyEdgeType { type InT = F#OutT } }](s: S):
+    def outE[S <: AnyPredicate { type ElementType <: AnyEdgeType { type In = F#Out } }](s: S):
         F >=> OutE[S] =
         f >=> OutE(s)
   }
@@ -98,7 +98,7 @@ object paths {
     // F:       K[A] -> M[B]
     //       S:           B  ->   N[C]
     // F map S: K[A] -> M[B] -> M[N[C]] 
-    def map[S <: AnyPath { type InC = ExactlyOne.type; type InT = F#OutT }](s: S): 
+    def map[S <: AnyPath { type In = ExactlyOne.Of[F#OutT] }](s: S): 
       F >=> (S MapOver F#OutC) = 
       f >=> MapOver(s, f.outC)
 


### PR DESCRIPTION
_I'm saving here some partial work for later and moving on._
### Context
#### How things are now:

``` scala
trait AnyPath {

  type InC <: AnyContainer
  val  inC: InC
  type InT <: AnyGraphType
  val  inT: InT

  type OutC <: AnyContainer
  val  outC: OutC
  type OutT <: AnyGraphType
  val  outT: OutT
}

object paths {
  type InOf[P <: AnyPath] = P#InC#Of[P#InT]
  type OutOf[P <: AnyPath] = P#OutC#Of[P#OutT]

  def inOf[P <: AnyPath](p: P): InOf[P] = p.inC(p.inT)
  def outOf[P <: AnyPath](p: P): OutOf[P] = p.outC(p.outT)
}
```

i.e. first order members are in/out container and type, whereas their combination is derived separately.
**This approach works**, and it's important. 

But when `InT <: AnyContainerType` (i.e. `AnyContainer.Of[AnyGraphType]`) this approach becomes non-uniform, because you disassemble that nested type and work with its members (`AnyContainerType#Container` and `AnyContainerType#Of`). So I thought, if that works fine, why not to use the same approach in the `AnyPath` itself?
#### Here is what this branch is trying to do:

``` scala
trait AnyPath {

  type In <: AnyContainerType
  val  in: In

  type InC = In#Container
  val  inC = in.container
  type InT = In#Of
  val  inT = in.of


  type Out <: AnyContainerType
  val  out: Out

  type OutC = Out#Container
  val  outC = out.container
  type OutT = Out#Of
  val  outT = out.of
}
```

i.e. `In` and `Out` become first-order members as container-types and their members are derived. This potentially leads to simplifications for defining steps and combinators. And the changes are not so big. But for finishing this we need to improve containers a bit, namely, for a particular `C <: AnyContainerType` to be able to express
- `C` with a particular type of container
- `C` with a particular type of Of
- `C` of a particular nested structure (e.g. two-level with particular containers)
